### PR TITLE
Return if packer checkout is performed

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -3,6 +3,7 @@ local install_path = vim.fn.stdpath 'data' .. '/site/pack/packer/start/packer.nv
 
 if vim.fn.empty(vim.fn.glob(install_path)) > 0 then
     vim.fn.execute('!git clone https://github.com/wbthomason/packer.nvim ' .. install_path)
+    return
 end
 
 vim.api.nvim_exec(


### PR DESCRIPTION
Added return statement in case packer install path is empty and a checkout of packer is performed.

Since packer is missing on first startup of neovim, the checkout is performed. Thus neovim wasn't able to load packer before reading the configuration and will fail if we perform the ` require('packer')` later. With the added return statement the first startup won't fail. Instead neovim will load without any configuration once and after a restart packer is present and the configuration is fully loaded.